### PR TITLE
feat(server): integrate IPFS configuration and module

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ipfs-force-community/threadmirror/pkg/database/sql"
 	"github.com/ipfs-force-community/threadmirror/pkg/database/sql/sqlfx"
 	"github.com/ipfs-force-community/threadmirror/pkg/i18n/i18nfx"
+	"github.com/ipfs-force-community/threadmirror/pkg/ipfs/ipfsfx"
 	"github.com/ipfs-force-community/threadmirror/pkg/llm/llmfx"
 	"github.com/ipfs-force-community/threadmirror/pkg/log/logfx"
 	"github.com/ipfs-force-community/threadmirror/pkg/util"
@@ -30,6 +31,7 @@ var ServerCommand = &cli.Command{
 		config.GetBotCLIFlags(),
 		config.GetAuth0CLIFlags(),
 		config.GetLLMCLIFlags(),
+		config.GetIPFSCLIFlags(),
 	),
 	Action: func(c *cli.Context) error {
 		serverConf := config.LoadServerConfigFromCLI(c)
@@ -38,12 +40,14 @@ var ServerCommand = &cli.Command{
 		debug := serverConf.Debug
 		auth0Conf := config.LoadAuth0ConfigFromCLI(c)
 		llmConf := config.LoadLLMConfigFromCLI(c)
+		ipfsConf := config.LoadIPFSConfigFromCLI(c)
 
 		fxApp := fx.New(
 			// Provide the configuration
 			fx.Supply(serverConf),
 			fx.Supply(botConf),
 			fx.Supply(llmConf),
+			fx.Supply(ipfsConf),
 			fx.Supply(&logfx.Config{
 				Level:      c.String("log-level"),
 				LogDevMode: debug,
@@ -60,6 +64,7 @@ var ServerCommand = &cli.Command{
 			authfx.ModuleAuth0(auth0Conf),
 			botfx.Module,
 			llmfx.Module,
+			ipfsfx.Module,
 			fx.Invoke(func(lc fx.Lifecycle, db *sql.DB) {
 				if debug {
 					lc.Append(fx.StartHook(migrateFn(db)))

--- a/example.env
+++ b/example.env
@@ -87,3 +87,13 @@ AUTH0_AUDIENCE=
 OPENAI_BASE_URL=
 OPENAI_API_KEY=
 OPENAI_MODEL=
+
+# ===========================================
+# IPFS Configuration
+# ===========================================
+
+# IPFS backend (kubo) (default: kubo)
+IPFS_BACKEND=kubo
+
+# IPFS node URL/multiaddr (default: /ip4/127.0.0.1/tcp/5001)
+IPFS_NODE_URL=/ip4/127.0.0.1/tcp/5001

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"time"
 
+	"github.com/ipfs-force-community/threadmirror/pkg/ipfs/ipfsfx"
 	"github.com/ipfs-force-community/threadmirror/pkg/llm/llmfx"
 	"github.com/urfave/cli/v2"
 )
@@ -69,6 +70,13 @@ func LoadBotConfigFromCLI(c *cli.Context) *BotConfig {
 		Email:            c.String("bot-email"),
 		CheckInterval:    c.Duration("bot-check-interval"),
 		MaxMentionsCheck: c.Int("bot-max-mentions"),
+	}
+}
+
+func LoadIPFSConfigFromCLI(c *cli.Context) *ipfsfx.Config {
+	return &ipfsfx.Config{
+		Backend: c.String("ipfs-backend"),
+		NodeURL: c.String("ipfs-node-url"),
 	}
 }
 
@@ -190,6 +198,24 @@ func GetLLMCLIFlags() []cli.Flag {
 			Value:   "gpt-4o-mini",
 			Usage:   "OpenAI model name",
 			EnvVars: []string{"OPENAI_MODEL"},
+		},
+	}
+}
+
+// GetIPFSCLIFlags returns IPFS-related CLI flags
+func GetIPFSCLIFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:    "ipfs-backend",
+			Value:   "kubo",
+			Usage:   "IPFS backend (kubo)",
+			EnvVars: []string{"IPFS_BACKEND"},
+		},
+		&cli.StringFlag{
+			Name:    "ipfs-node-url",
+			Value:   "/ip4/127.0.0.1/tcp/5001",
+			Usage:   "IPFS node URL/multiaddr",
+			EnvVars: []string{"IPFS_NODE_URL"},
 		},
 	}
 }


### PR DESCRIPTION
## Description
This PR integrates IPFS configuration into the ThreadMirror server, allowing the application to connect to and interact with IPFS nodes.

## Changes Made
- **Server Integration**: Added IPFS module to the server startup process in `cmd/server.go`
- **Configuration Support**: Added IPFS CLI flags and configuration loading in `internal/config/config.go`
- **Environment Variables**: Updated `example.env` with IPFS configuration options

## Configuration Options
- `IPFS_BACKEND`: IPFS backend type (default: kubo)
- `IPFS_NODE_URL`: IPFS node URL/multiaddr (default: /ip4/127.0.0.1/tcp/5001)

## Technical Details
- Follows the existing patterns for module integration using dependency injection
- Maintains backward compatibility with existing server configurations
- Uses environment variables for flexible deployment configurations

## Testing
- [ ] Verify server starts successfully with IPFS module
- [ ] Test IPFS connectivity with different node URLs
- [ ] Validate configuration loading from CLI and environment variables