### PR TITLE
fix(service): use author.RestID instead of author.ID in post creation

### DIFF
--- a/internal/service/post_service.go
+++ b/internal/service/post_service.go
@@ -115,7 +115,7 @@ func (s *PostService) CreatePost(
 	var authorID, authorName, authorScreenName, authorProfileImageURL string
 	if req.Tweets[0].Author != nil {
 		author := req.Tweets[0].Author
-		authorID = author.ID
+		authorID = author.RestID
 		authorName = author.Name
 		authorScreenName = author.ScreenName
 		authorProfileImageURL = author.ProfileImageURL


### PR DESCRIPTION
## Summary

This PR fixes a bug in the post creation service where we were using `author.ID` instead of `author.RestID` when extracting author information from tweets.

## Changes

- Fixed field reference in `internal/service/post_service.go` line 118
- Changed `authorID = author.ID` to `authorID = author.RestID`

## Rationale

The xscraper Tweet Author struct uses `RestID` as the field name for the author's ID, not `ID`. This ensures we're correctly capturing the author's ID when creating posts.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] The code builds successfully
- [ ] All existing tests pass
- [ ] New tests have been added (if applicable)